### PR TITLE
feat: protoreflect, manually register skipped files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/emicklei/proto v1.11.0
 	github.com/goccy/go-json v0.9.10
+	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/roadrunner-server/api/v2 v2.20.0
 	github.com/roadrunner-server/errors v1.1.2
@@ -25,7 +26,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/emicklei/proto v1.11.0
 	github.com/goccy/go-json v0.9.10
-	github.com/google/uuid v1.3.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/roadrunner-server/api/v2 v2.20.0
 	github.com/roadrunner-server/errors v1.1.2
@@ -26,6 +25,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,6 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/roadrunner-server/api/v2 v2.19.0 h1:tabuboUR9mK8vnyKXNws++bwq17dO8OFFEaRlsu1tqg=
-github.com/roadrunner-server/api/v2 v2.19.0/go.mod h1:VDlFUKfyL2nKCY1aaIKNlDwi7c9B158RKdJ4jif4h9w=
 github.com/roadrunner-server/api/v2 v2.20.0 h1:VyWesy/EQGVcTk35KufUgUWSPwGprbC/N92Wb9t9NnM=
 github.com/roadrunner-server/api/v2 v2.20.0/go.mod h1:9AvCOEhbNyfPuCCsrpL84TFb0k56BPmYQ6tUBNLS58c=
 github.com/roadrunner-server/errors v1.1.2 h1:+LPw9Akgg+8LAGM4wASMWLAoBIbyP+mhNfR+FBS2Slw=
@@ -335,8 +333,6 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
-golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -356,8 +352,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -405,8 +399,6 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220721230656-c6bc011c0c49 h1:TMjZDarEwf621XDryfitp/8awEhiZNiwgphKlTMGRIg=
-golang.org/x/sys v0.0.0-20220721230656-c6bc011c0c49/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -520,8 +512,6 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20220720214146-176da50484ac h1:EOa+Yrhx1C0O+4pHeXeWrCwdI0tWI6IfUU56Vebs9wQ=
-google.golang.org/genproto v0.0.0-20220720214146-176da50484ac/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
 google.golang.org/genproto v0.0.0-20220722212130-b98a9ff5e252 h1:G5AjFxR+ibe9Taamo0TdW+iylfBYK10DSkHYdx7PZ9w=
 google.golang.org/genproto v0.0.0-20220722212130-b98a9ff5e252/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/plugin.go
+++ b/plugin.go
@@ -3,6 +3,9 @@ package grpc
 import (
 	"context"
 	stderr "errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sync"
 
 	"github.com/roadrunner-server/api/v2/plugins/config"
@@ -20,6 +23,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
 
 	// Will register via init
 	_ "google.golang.org/grpc/encoding/gzip"
@@ -36,7 +43,6 @@ type Plugin struct {
 	config        *Config
 	gPool         pool.Pool
 	opts          []grpc.ServerOption
-	services      []func(server *grpc.Server)
 	server        *grpc.Server
 	rrServer      server.Server
 	proxyList     []*proxy.Proxy
@@ -68,7 +74,6 @@ func (p *Plugin) Init(cfg config.Configurer, log *zap.Logger, server server.Serv
 	}
 
 	p.opts = make([]grpc.ServerOption, 0)
-	p.services = make([]func(server *grpc.Server), 0)
 	p.rrServer = server
 	p.proxyList = make([]*proxy.Proxy, 0, 1)
 
@@ -111,12 +116,6 @@ func (p *Plugin) Serve() chan error {
 		return errCh
 	}
 
-	// register reflection server
-	// doc: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
-	if p.config.EnableReflectionServer {
-		reflection.Register(p.server)
-	}
-
 	l, err := utils.CreateListener(p.config.Listen)
 	if err != nil {
 		errCh <- errors.E(op, err)
@@ -125,6 +124,18 @@ func (p *Plugin) Serve() chan error {
 
 	p.healthServer = NewHeathServer(p, p.log)
 	p.healthServer.RegisterServer(p.server)
+
+	// register reflection server
+	// doc: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
+	if p.config.EnableReflectionServer {
+		reflection.Register(p.server)
+		// register proto descriptions manually
+		err = registerProtoFile(p.config.Proto)
+		if err != nil {
+			errCh <- err
+			return errCh
+		}
+	}
 
 	go func() {
 		p.log.Info("grpc server was started", zap.String("address", p.config.Listen))
@@ -200,4 +211,85 @@ func (p *Plugin) Workers() []*process.State {
 	}
 
 	return ps
+}
+
+func registerProtoFile(protofiles []string) error {
+	for i := 0; i < len(protofiles); i++ {
+		// get absolute path to the file
+		absPath, err := filepath.Abs(filepath.Dir(protofiles[i]))
+		if err != nil {
+			return err
+		}
+
+		fileName := filepath.Base(protofiles[i])
+
+		// check if we already have the file registered
+		_, err = protoregistry.GlobalFiles.FindFileByPath(fileName)
+		// it's ok if file not found, we need to register it
+		if err != nil && !stderr.Is(err, protoregistry.NotFound) {
+			return err
+		}
+		// we should avoid registering duplicates, that leads to panic
+		// if err is eq to nil, than we found a file and should avoid to double-register it
+		if err == nil {
+			continue
+		}
+
+		// save the file in the temp: /tmp/fileName_tmp.pb
+		tmpFile := filepath.Join(os.TempDir(), fileName+"_tmp.pb")
+		cmd := exec.Command( //nolint:gosec
+			"protoc",
+			"--descriptor_set_out="+tmpFile,
+			// include also files from the original dir + our proto file
+			"-I"+absPath, filepath.Join(absPath, fileName))
+
+		// redirect messages from the command
+		// user should see and error if any
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err = cmd.Run()
+		if err != nil {
+			_ = os.Remove(tmpFile)
+			return err
+		}
+
+		protoFile, err := os.ReadFile(tmpFile)
+		if err != nil {
+			_ = os.Remove(tmpFile)
+			return err
+		}
+
+		fdSet := new(descriptorpb.FileDescriptorSet)
+		err = proto.Unmarshal(protoFile, fdSet)
+		if err != nil {
+			_ = os.Remove(tmpFile)
+			return err
+		}
+
+		// no files
+		if len(fdSet.GetFile()) < 1 {
+			continue
+		}
+
+		// we need only first
+		pb := fdSet.GetFile()[0]
+
+		fd, err := protodesc.NewFile(pb, protoregistry.GlobalFiles)
+		if err != nil {
+			_ = os.Remove(tmpFile)
+			return err
+		}
+
+		// register file
+		err = protoregistry.GlobalFiles.RegisterFile(fd)
+		if err != nil {
+			_ = os.Remove(tmpFile)
+			return err
+		}
+
+		_ = os.Remove(tmpFile)
+	}
+
+	return nil
 }

--- a/server.go
+++ b/server.go
@@ -33,9 +33,9 @@ func (p *Plugin) createGRPCserver() (*grpc.Server, error) {
 		}
 
 		// php proxy services
-		services, err := parser.File(p.config.Proto[i], path.Dir(p.config.Proto[i]))
-		if err != nil {
-			return nil, err
+		services, errP := parser.File(p.config.Proto[i], path.Dir(p.config.Proto[i]))
+		if errP != nil {
+			return nil, errP
 		}
 
 		for _, service := range services {
@@ -47,11 +47,6 @@ func (p *Plugin) createGRPCserver() (*grpc.Server, error) {
 			server.RegisterService(px.ServiceDesc(), px)
 			p.proxyList = append(p.proxyList, px)
 		}
-	}
-
-	// external and native  services
-	for _, r := range p.services {
-		r(server)
 	}
 
 	return server, nil


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1224
ref: https://github.com/roadrunner-server/roadrunner/issues/1223

## Description of Changes

- Go's gRPC server may skip proto files from registering if unused. But since we're using gRPC from the PHP, we need to register all files.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
