### PR TITLE
feat: base64 decoder for the `errorProto` status

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -206,7 +206,7 @@ func (p *Proxy) responseMetadata(resp *payload.Payload) (metadata.MD, error) {
 				return nil, err
 			}
 
-			return nil, status.ErrorProto(st)
+			return md, status.ErrorProto(st)
 		}
 	}
 


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1273

## Description of Changes

- Decode `base64` encoded string with google's error proto.
- GoDoc: https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/status

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
