### PR TITLE
fix: `buf` Dockerfile name collision

### DIFF
--- a/protoc_plugins/Dockerfile
+++ b/protoc_plugins/Dockerfile
@@ -7,7 +7,7 @@ COPY protoc_plugins/ .
 RUN go mod download
 RUN go mod tidy
 
-RUN go build -trimpath -ldflags "-s" -o protoc-gen-php-grpc protoc-gen-php-grpc/main.go
+RUN go build -trimpath -ldflags "-s" -o protoc-gen-php-grpc-plugin protoc-gen-php-grpc/main.go
 
 FROM scratch
 
@@ -19,6 +19,6 @@ LABEL "build.buf.plugins.runtime_library_versions.0.version"="$APP_VERSION"
 LABEL "build.buf.plugins.runtime_library_versions.1.name"="google.golang.org/protobuf"
 LABEL "build.buf.plugins.runtime_library_versions.1.version"="v1.27.1"
 
-COPY --from=builder /src/protoc-gen-php-grpc /
+COPY --from=builder /src/protoc-gen-php-grpc-plugin /
 
-ENTRYPOINT ["/protoc-gen-php-grpc"]
+ENTRYPOINT ["/protoc-gen-php-grpc-plugin"]

--- a/protoc_plugins/go.mod
+++ b/protoc_plugins/go.mod
@@ -3,7 +3,7 @@ module github.com/roadrunner-server/grpc/protoc_plugins/v2
 go 1.19
 
 require (
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/protoc_plugins/go.sum
+++ b/protoc_plugins/go.sum
@@ -14,9 +14,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=


### PR DESCRIPTION
# Reason for This PR

- closes: https://github.com/roadrunner-server/roadrunner/issues/1341

## Description of Changes

- Update the plugin name inside the Dockerfile to avoid name collision with the folder.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
