### PR TITLE
feat(metrics): `queueSize`,  `requestCounter` and `requestDuration` metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -14,7 +14,7 @@ type Informer interface {
 func (p *Plugin) MetricsCollector() []prometheus.Collector {
 	// p - implements Exporter interface (workers)
 	// other - request duration and count
-	return []prometheus.Collector{p.statsExporter}
+	return []prometheus.Collector{p.statsExporter, p.requestCounter, p.requestDuration, p.queueSize}
 }
 
 const (

--- a/server.go
+++ b/server.go
@@ -54,7 +54,15 @@ func (p *Plugin) createGRPCserver() (*grpc.Server, error) {
 
 func (p *Plugin) interceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	start := time.Now()
+
+	p.queueSize.Inc()
+
 	resp, err := handler(ctx, req)
+
+	defer p.requestCounter.WithLabelValues(info.FullMethod).Inc()
+	defer p.requestDuration.WithLabelValues(info.FullMethod).Observe(time.Since(start).Seconds())
+	defer p.queueSize.Dec()
+
 	if err != nil {
 		p.log.Error("method call was finished with error", zap.Error(err), zap.String("method", info.FullMethod), zap.Time("start", start), zap.Duration("elapsed", time.Since(start)))
 

--- a/server.go
+++ b/server.go
@@ -59,9 +59,11 @@ func (p *Plugin) interceptor(ctx context.Context, req any, info *grpc.UnaryServe
 
 	resp, err := handler(ctx, req)
 
-	defer p.requestCounter.WithLabelValues(info.FullMethod).Inc()
-	defer p.requestDuration.WithLabelValues(info.FullMethod).Observe(time.Since(start).Seconds())
-	defer p.queueSize.Dec()
+	defer func() {
+		p.requestCounter.WithLabelValues(info.FullMethod).Inc()
+		p.requestDuration.WithLabelValues(info.FullMethod).Observe(time.Since(start).Seconds())
+		p.queueSize.Dec()
+	}()
 
 	if err != nil {
 		p.log.Error("method call was finished with error", zap.Error(err), zap.String("method", info.FullMethod), zap.Time("start", start), zap.Duration("elapsed", time.Since(start)))


### PR DESCRIPTION
# Reason for This PR

I tested Grafana dashboards for RR and I figured out that some graphs not working at all.

https://github.com/roadrunner-server/roadrunner/blob/master/dashboards/grpc_dashboard.json

## Description of Changes

In this PR I added missing metrics `requests_queue`, `request_total` and `request_duration_seconds` (The same exists for HTTP plugin).

E2E: https://github.com/roadrunner-server/rr-e2e-tests/pull/208
Doc: https://github.com/spiral/roadrunner-docs/pull/123

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

---
@rustatian I will add E2E tests if you agree to proceed with such PR.