### PR TITLE
fix: protect pool creation operation

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -117,6 +117,9 @@ func (p *Plugin) Serve() chan error {
 	const op = errors.Op("grpc_plugin_serve")
 	errCh := make(chan error, 1)
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	var err error
 	p.gPool, err = p.rrServer.NewPool(context.Background(), &pool.Config{
 		Debug:           p.config.GrpcPool.Debug,


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1532

## Description of Changes

- Protect the pool of workers from being accessed while it's still being created.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
