### PR TITLE
feature: allow specifying wildcards in the grpc.proto setting

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,51 @@
+package grpc
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const separator = string(filepath.Separator)
+
+func TestInitDefaults(t *testing.T) {
+	c := Config{}
+	assert.Error(t, c.InitDefaults())
+
+	c.Listen = "localhost:1234"
+	assert.NoError(t, c.InitDefaults())
+
+	c.Proto = []string{""}
+	assert.NoError(t, c.InitDefaults())
+	assert.Empty(t, c.Proto)
+
+	c.Proto = []string{"parser/pong.proto"}
+	assert.NoError(t, c.InitDefaults())
+	assert.Equal(t, []string{"parser/pong.proto"}, c.Proto)
+
+	c.Proto = []string{"parser/nonexitent*.notproto"}
+	assert.NoError(t, c.InitDefaults())
+	assert.Empty(t, c.Proto)
+
+	c.Proto = []string{"config.go", "parser/*.proto"}
+	assert.NoError(t, c.InitDefaults())
+	assert.Equal(t, []string{
+		"config.go",
+		"parser" + separator + "message.proto",
+		"parser" + separator + "pong.proto",
+		"parser" + separator + "test.proto",
+		"parser" + separator + "test_import.proto",
+	}, c.Proto)
+
+	c.Proto = []string{"parser/?est.proto"}
+	assert.NoError(t, c.InitDefaults())
+	assert.Equal(t, []string{"parser" + separator + "test.proto"}, c.Proto)
+
+	c.Proto = []string{"parser/[tb]est.proto"}
+	assert.NoError(t, c.InitDefaults())
+	assert.Equal(t, []string{"parser" + separator + "test.proto"}, c.Proto)
+
+	c.Proto = []string{"[[[error"}
+	assert.Error(t, c.InitDefaults())
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -230,6 +230,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 h1:hzAQntlaYRkVSFEfj9OTWlVV1H155FMD8BTKktLv0QI=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1 h1:zH8ljVhhq7yC0MIeUL/IviMtY8hx2mK8cN9wEYb8ggw=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -281,6 +282,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
@@ -293,6 +295,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/roadrunner-server/endure/v2 v2.0.1 h1:2greoQ669iCjsYNt14dwXXQGHAKDmLtFzL0OIE0ZATc=
 github.com/roadrunner-server/endure/v2 v2.0.1/go.mod h1:RDrC9SFlyCGqGA2v9SqFIA+EqWTFmPxafIb4SMeHCHM=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
# Reason for This PR

ref: roadrunner-php/grpc#14

In large projects, maintaining the list of protofiles becomes a chore, allow using filename wildcards (e.g. path/to/*.proto)

## Description of Changes

Expand wildcards in Config.InitDefaults()

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
