### PR TITLE
chore(tests): use resetter v6 proto messages in sendReset

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,6 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
+	github.com/roadrunner-server/api-go/v6 v6.0.0-beta.13
 	github.com/roadrunner-server/config/v6 v6.0.0-beta.3
 	github.com/roadrunner-server/endure/v2 v2.6.2
 	github.com/roadrunner-server/goridge/v4 v4.0.0-beta.3
@@ -26,7 +27,6 @@ require (
 	github.com/jhump/protoreflect v1.18.0 // indirect
 	github.com/jhump/protoreflect/v2 v2.0.0-beta.2 // indirect
 	github.com/petermattis/goid v0.0.0-20260713124913-97594f28f5ca // indirect
-	github.com/roadrunner-server/api-go/v6 v6.0.0-beta.13 // indirect
 	github.com/roadrunner-server/api-plugins/v6 v6.0.0-beta.2 // indirect
 	github.com/roadrunner-server/pool/v2 v2.0.0-beta.1 // indirect
 	go.uber.org/zap v1.28.0 // indirect

--- a/tests/grpc_plugin_test.go
+++ b/tests/grpc_plugin_test.go
@@ -1066,12 +1066,12 @@ func sendReset(address string) func(t *testing.T) {
 
 		resp := &resetterV1.Response{}
 		err = client.Call("resetter.Reset", &resetterV1.ResetRequest{Plugin: "grpc"}, resp)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, resp.GetOk())
 
 		list := &resetterV1.PluginsList{}
 		err = client.Call("resetter.ListPlugins", &resetterV1.ListPluginsRequest{}, list)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.Equal(t, []string{"grpc"}, list.GetPlugins())
 	}
 }

--- a/tests/grpc_plugin_test.go
+++ b/tests/grpc_plugin_test.go
@@ -19,6 +19,7 @@ import (
 	mocklogger "tests/mock"
 	"tests/proto/service"
 
+	resetterV1 "github.com/roadrunner-server/api-go/v6/resetter/v1"
 	"github.com/roadrunner-server/config/v6"
 	"github.com/roadrunner-server/endure/v2"
 	goridgeRpc "github.com/roadrunner-server/goridge/v4/pkg/rpc"
@@ -1062,19 +1063,16 @@ func sendReset(address string) func(t *testing.T) {
 		require.NoError(t, err)
 		client := rpc.NewClientWithCodec(goridgeRpc.NewClientCodec(conn))
 		defer func() { _ = client.Close() }()
-		// WorkerList contains list of workers.
 
-		var ret bool
-		err = client.Call("resetter.Reset", "grpc", &ret)
+		resp := &resetterV1.Response{}
+		err = client.Call("resetter.Reset", &resetterV1.ResetRequest{Plugin: "grpc"}, resp)
 		assert.NoError(t, err)
-		assert.True(t, ret)
-		ret = false
+		assert.True(t, resp.GetOk())
 
-		var services []string
-		err = client.Call("resetter.List", nil, &services)
-		assert.NotNil(t, services)
+		list := &resetterV1.PluginsList{}
+		err = client.Call("resetter.ListPlugins", &resetterV1.ListPluginsRequest{}, list)
 		assert.NoError(t, err)
-		require.Equal(t, []string{"grpc"}, services)
+		require.Equal(t, []string{"grpc"}, list.GetPlugins())
 	}
 }
 


### PR DESCRIPTION
sendReset still called resetter.Reset/List with the pre-v6 primitive payloads. Switch to resetterV1 ResetRequest/Response and ListPlugins over the same goridge net/rpc client.